### PR TITLE
Fixed coverage values

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -40,10 +40,10 @@ const (
 )
 
 var regex *regexp.Regexp
-var regexpStringFilename = `(?P<filename>[a-zA-Z\/\._\d]*)`
-var regexpStringLine = `(?P<line>\d*)`
-var regexpStringNumStatements = `(?P<nstatements>\d*)`
-var regexpStringCountStatements = `(?P<cstatements>\d*)`
+var regexpStringFilename = `([a-zA-Z\/\._\d]*)`
+var regexpStringLine = `(\d*)`
+var regexpStringNumStatements = `(\d*)`
+var regexpStringCountStatements = `(\d*)`
 var regexpStringMode = `mode: ([set|count|atomic]*)`
 var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringNumStatements, regexpStringCountStatements)
 

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -3,6 +3,7 @@ package coverage
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"regexp"
 	"strconv"
@@ -34,11 +35,16 @@ type codacyFileCoverageJSON struct {
 }
 
 var regex *regexp.Regexp
+var regexpStringFilename = `(?P<filename>[a-zA-Z\/\._\d]*)`
+var regexpStringLine = `(?P<line>\d*)`
+var regexpStringNumStatements = `(?P<nstatements>\d*)`
+var regexpStringCountStatements = `(?P<cstatements>\d*)`
+var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringNumStatements, regexpStringCountStatements)
 
 // GenerateCoverageJSON generates a json string containing
 // coverage information in codacy's format
 func GenerateCoverageJSON(coverageFile string) ([]byte, error) {
-	regex, _ = regexp.Compile(`([a-zA-Z\/\.]*):(\d*)\..* (\d*) (\d*)`)
+	regex, _ = regexp.Compile(regexpString)
 
 	dat, err := ioutil.ReadFile(coverageFile)
 	lines := strings.Split(string(dat), "\n")
@@ -88,7 +94,6 @@ func GenerateCoverageJSON(coverageFile string) ([]byte, error) {
 
 func parseLine(line string) (reportLine, error) {
 	result := regex.FindStringSubmatch(line)
-
 	if len(result) >= 5 {
 		line, err := strconv.Atoi(result[2])
 		if err != nil {
@@ -128,4 +133,8 @@ func calculatePercentage(num int, cnt int) float64 {
 		return 0
 	}
 	return float64(cnt) / float64(num)
+}
+
+func compileRegexp() (*regexp.Regexp, error) {
+	return regexp.Compile(regexpString)
 }

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -41,10 +41,9 @@ const (
 
 var regex *regexp.Regexp
 var regexpStringFilename = `([a-zA-Z\/\._\d]*)`
-var regexpStringLine = `(\d*)`
-var regexpStringStats = `(\d*)`
+var regexpStringStat = `(\d*)`
 var regexpStringMode = `mode: ([set|count|atomic]*)`
-var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringStats, regexpStringStats)
+var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringStat, regexpStringStat, regexpStringStat)
 
 // GenerateCoverageJSON generates a json string containing
 // coverage information in codacy's format

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -42,10 +42,9 @@ const (
 var regex *regexp.Regexp
 var regexpStringFilename = `([a-zA-Z\/\._\d]*)`
 var regexpStringLine = `(\d*)`
-var regexpStringNumStatements = `(\d*)`
-var regexpStringCountStatements = `(\d*)`
+var regexpStringStats = `(\d*)`
 var regexpStringMode = `mode: ([set|count|atomic]*)`
-var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringNumStatements, regexpStringCountStatements)
+var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringStats, regexpStringStats)
 
 // GenerateCoverageJSON generates a json string containing
 // coverage information in codacy's format

--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -34,11 +34,16 @@ type codacyFileCoverageJSON struct {
 	Coverage map[int]int `json:"coverage"`
 }
 
+const (
+	ModeSet = "set"
+)
+
 var regex *regexp.Regexp
 var regexpStringFilename = `(?P<filename>[a-zA-Z\/\._\d]*)`
 var regexpStringLine = `(?P<line>\d*)`
 var regexpStringNumStatements = `(?P<nstatements>\d*)`
 var regexpStringCountStatements = `(?P<cstatements>\d*)`
+var regexpStringMode = `mode: ([set|count|atomic]*)`
 var regexpString = fmt.Sprintf(`%s:%s\..* %s %s`, regexpStringFilename, regexpStringLine, regexpStringNumStatements, regexpStringCountStatements)
 
 // GenerateCoverageJSON generates a json string containing
@@ -122,6 +127,7 @@ func calculatePercentages(files map[string]*fileCoverage) (float64, map[string]f
 	for file, coverage := range files {
 		totalNumStatements += coverage.numStatements
 		totalCntStatements += coverage.cntStatements
+		fmt.Println(totalNumStatements, totalCntStatements)
 		percentages[file] = calculatePercentage(coverage.numStatements, coverage.cntStatements)
 	}
 

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,0 +1,21 @@
+package coverage
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+var testFilename = "github.com/user/repo/a/b/c/1/my_file.go"
+
+func TestRegexp(t *testing.T) {
+	r, _ := regexp.Compile(regexpStringFilename)
+	result := r.FindStringSubmatch(testFilename)
+	if len(result) < 2 {
+		fmt.Println(result)
+		t.Fatal("filename should match")
+	}
+	if testFilename != result[1] {
+		t.Error("filename is not valid")
+	}
+}

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -8,7 +8,7 @@ import (
 
 var testFilename = "github.com/user/repo/a/b/c/1/my_file.go"
 
-func TestRegexp(t *testing.T) {
+func TestRegexpFilename(t *testing.T) {
 	r, _ := regexp.Compile(regexpStringFilename)
 	result := r.FindStringSubmatch(testFilename)
 	if len(result) < 2 {
@@ -17,5 +17,18 @@ func TestRegexp(t *testing.T) {
 	}
 	if testFilename != result[1] {
 		t.Error("filename is not valid")
+	}
+}
+
+func TestRegexpMode(t *testing.T) {
+	modeString := "mode: set"
+	r, _ := regexp.Compile(regexpStringMode)
+	result := r.FindStringSubmatch(modeString)
+	if len(result) < 2 {
+		fmt.Println(result)
+		t.Fatal("invalid mode")
+	}
+	if ModeSet != result[1] {
+		t.Error("expected set mode")
 	}
 }

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -7,12 +7,12 @@ import (
 )
 
 var testFilename = "github.com/user/repo/a/b/c/1/my_file.go"
+var testLine = fmt.Sprintf("%s:16.45,19.24 2 1", testFilename)
 
 func TestRegexpFilename(t *testing.T) {
 	r, _ := regexp.Compile(regexpStringFilename)
 	result := r.FindStringSubmatch(testFilename)
 	if len(result) < 2 {
-		fmt.Println(result)
 		t.Fatal("filename should match")
 	}
 	if testFilename != result[1] {
@@ -25,10 +25,60 @@ func TestRegexpMode(t *testing.T) {
 	r, _ := regexp.Compile(regexpStringMode)
 	result := r.FindStringSubmatch(modeString)
 	if len(result) < 2 {
-		fmt.Println(result)
 		t.Fatal("invalid mode")
 	}
 	if ModeSet != result[1] {
 		t.Error("expected set mode")
 	}
+}
+
+func TestCalculatePercentages(t *testing.T) {
+	files := map[string]*fileCoverage{
+		"a": &fileCoverage{
+			numStatements:     12,
+			cntStatements:     6,
+			coveredStatements: 11,
+			lines: map[int]int{
+				46: 2,
+				55: 2,
+				73: 2,
+				51: 0,
+			},
+		},
+	}
+	total, perFile := calculatePercentages(files)
+	if total != 91 {
+		t.Error(fmt.Sprintf("expected 91%%, received %v%% \n", total))
+	}
+	if perFile["a"] != 91 {
+		t.Error(fmt.Sprintf("expected 91%%, received %v%% \n", perFile["a"]))
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	regex, _ = compileRegexp()
+	report, err := parseLine(testLine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.numStatements != 2 {
+		t.Error("expected 2 statements")
+	}
+	if report.cntStatements != 1 {
+		t.Error("expected count to be 2")
+	}
+}
+
+func TestParseLineFailsWithBadFormat(t *testing.T) {
+	expectParseLineFails(t, fmt.Sprintf("%s:16.45,19.24 100000000000000000000 1", testFilename))
+	expectParseLineFails(t, fmt.Sprintf("%s:16.45,19.24 1 100000000000000000000", testFilename))
+	expectParseLineFails(t, fmt.Sprintf("%s:16.sdvsfbvs", testFilename))
+}
+
+func expectParseLineFails(t *testing.T, line string) {
+	_, err := parseLine(line)
+	if err != nil {
+		return
+	}
+	t.Error("expected an error")
 }


### PR DESCRIPTION
* Split subexpressions so they can be tested separately
* Coverage is calculed by dividing the number of statements by the number of statements covered.