### PR TITLE
explicitly check for lines in the coverage profile that should be skipped

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -57,7 +57,10 @@ func GenerateCoverageJSON(coverageFile string) ([]byte, error) {
 	}
 
 	files := make(map[string]*fileCoverage)
-	for _, line := range lines[1 : len(lines)-1] {
+	for _, line := range lines {
+		if isSkippableLine(line) {
+			continue
+		}
 		parsed, err := parseLine(line)
 		if err != nil {
 			return nil, err
@@ -118,6 +121,10 @@ func parseLine(line string) (reportLine, error) {
 	}
 
 	return reportLine{}, errors.New("Invalid line format")
+}
+
+func isSkippableLine(line string) bool {
+	return (len(strings.TrimSpace(line)) == 0) || strings.HasPrefix(line, "mode")
 }
 
 func calculatePercentages(files map[string]*fileCoverage) (int, map[string]int) {

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -82,3 +82,15 @@ func expectParseLineFails(t *testing.T, line string) {
 	}
 	t.Error("expected an error")
 }
+
+func TestSkippableLine(t *testing.T) {
+	if !isSkippableLine(" ") {
+		t.Error("empty lines should be skipped")
+	}
+	if !isSkippableLine("mode: atomic") {
+		t.Error("lines only reporting coverage mode should be skipped")
+	}
+	if isSkippableLine("something else") {
+		t.Error("by default lines should not be skipped")
+	}
+}


### PR DESCRIPTION
A quick patch to address #9.

Thanks for creating this project. 👍 